### PR TITLE
Improve detect page layout and add skeleton loading

### DIFF
--- a/code/src/features/detect/video/index.tsx
+++ b/code/src/features/detect/video/index.tsx
@@ -10,6 +10,7 @@ const DetectPage: React.FC = () => {
   const [model, setModel] = useState<string>("YOLO-Fake");
   const [threshold, setThreshold] = useState<number>(0.7);
   const [interval, setInterval] = useState<number>(1);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleDetect = async () => {
@@ -17,20 +18,27 @@ const DetectPage: React.FC = () => {
       toast.error("请先上传视频");
       return;
     }
+    setLoading(true);
     const id = toast.loading("正在检测...");
     await new Promise((resolve) => setTimeout(resolve, 1500));
     toast.success("检测完成", { id });
+    setLoading(false);
     navigate("/result?id=123");
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 dark:bg-[#181A20] text-gray-900 dark:text-white">
+    <div className="relative min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white">
       <Toaster position="top-right" />
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 z-50">
+          <div className="w-40 h-40 bg-gray-200 dark:bg-gray-700 rounded-xl animate-pulse" />
+        </div>
+      )}
       <main className="max-w-4xl mx-auto py-8 px-4 space-y-6">
-        <div className="bg-white dark:bg-[#232B55] rounded-xl shadow p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6">
           <UploadZone onFileChange={setFile} />
         </div>
-        <div className="bg-white dark:bg-[#232B55] rounded-xl shadow p-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6">
           <DetectParams
             model={model}
             onModelChange={setModel}
@@ -40,7 +48,7 @@ const DetectPage: React.FC = () => {
             onIntervalChange={setInterval}
           />
         </div>
-        <div className="bg-white dark:bg-[#232B55] rounded-xl shadow p-6 text-center">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-6 text-center">
           <DetectButton onClick={handleDetect} />
         </div>
       </main>


### PR DESCRIPTION
## Summary
- style Detect page with card containers and dark mode classes
- show a skeleton overlay when starting detection

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68554c3124848331adf2348fb47faa1d