### PR TITLE
Improve DetectButton logic

### DIFF
--- a/code/src/features/detect/video/components/DetectButton.tsx
+++ b/code/src/features/detect/video/components/DetectButton.tsx
@@ -1,16 +1,42 @@
 import React from "react";
+import { toast } from "sonner";
+import { useNavigate } from "react-router-dom";
 
 export interface DetectButtonProps {
-  onClick: () => void;
+  file: File | null;
+  model: string;
+  threshold: number;
+  interval: number;
 }
 
-const DetectButton: React.FC<DetectButtonProps> = ({ onClick }) => (
-  <button
-    onClick={onClick}
-    className="w-full py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white transition"
-  >
-    开始检测
-  </button>
-);
+const DetectButton: React.FC<DetectButtonProps> = ({
+  file,
+  model,
+  threshold,
+  interval,
+}) => {
+  const navigate = useNavigate();
+
+  const handleClick = async () => {
+    if (!file || !model || threshold === undefined || interval === undefined) {
+      toast.error("请上传视频并填写检测参数");
+      return;
+    }
+
+    const id = toast.loading("正在检测...");
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    toast.success("检测完成", { id });
+    navigate("/result?id=mock123");
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="w-full py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white transition"
+    >
+      开始检测
+    </button>
+  );
+};
 
 export default DetectButton;

--- a/code/src/features/detect/video/index.tsx
+++ b/code/src/features/detect/video/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Toaster, toast } from "sonner";
+import { Toaster } from "sonner";
 import UploadZone from "./components/UploadZone";
 import DetectParams from "./components/DetectParams";
 import DetectButton from "./components/DetectButton";
@@ -10,18 +9,6 @@ const DetectPage: React.FC = () => {
   const [model, setModel] = useState<string>("YOLO-Fake");
   const [threshold, setThreshold] = useState<number>(0.7);
   const [interval, setInterval] = useState<number>(1);
-  const navigate = useNavigate();
-
-  const handleDetect = async () => {
-    if (!file) {
-      toast.error("请先上传视频");
-      return;
-    }
-    const id = toast.loading("正在检测...");
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    toast.success("检测完成", { id });
-    navigate("/result?id=123");
-  };
 
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-[#181A20] text-gray-900 dark:text-white">
@@ -41,7 +28,12 @@ const DetectPage: React.FC = () => {
           />
         </div>
         <div className="bg-white dark:bg-[#232B55] rounded-xl shadow p-6 text-center">
-          <DetectButton onClick={handleDetect} />
+          <DetectButton
+            file={file}
+            model={model}
+            threshold={threshold}
+            interval={interval}
+          />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- handle detection inside DetectButton
- add param checks and loading/success toasts
- navigate to `/result?id=mock123`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68554c2744f48331a08d8a56818f7af6