### PR TITLE
Add video detection service

### DIFF
--- a/code/src/features/detect/video/index.tsx
+++ b/code/src/features/detect/video/index.tsx
@@ -4,6 +4,7 @@ import { Toaster, toast } from "sonner";
 import UploadZone from "./components/UploadZone";
 import DetectParams from "./components/DetectParams";
 import DetectButton from "./components/DetectButton";
+import { detectVideo } from "../../services/detect";
 
 const DetectPage: React.FC = () => {
   const [file, setFile] = useState<File | null>(null);
@@ -17,10 +18,18 @@ const DetectPage: React.FC = () => {
       toast.error("请先上传视频");
       return;
     }
-    const id = toast.loading("正在检测...");
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    toast.success("检测完成", { id });
-    navigate("/result?id=123");
+    const loadingId = toast.loading("正在提交检测任务...");
+    try {
+      const taskId = await detectVideo(file, {
+        model,
+        threshold,
+        interval,
+      });
+      toast.success("检测已启动", { id: loadingId });
+      navigate(`/result?id=${taskId}`);
+    } catch (e) {
+      toast.error("检测失败", { id: loadingId });
+    }
   };
 
   return (

--- a/code/src/services/detect.ts
+++ b/code/src/services/detect.ts
@@ -1,0 +1,17 @@
+export interface DetectParams {
+  model: string;
+  threshold: number;
+  interval: number;
+}
+
+/**
+ * 模拟向后端提交视频检测任务，返回任务 ID
+ */
+export async function detectVideo(file: File, params: DetectParams): Promise<string> {
+  console.log('detectVideo', file.name, params);
+  // 模拟网络请求延迟
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  // 简单生成一个随机 taskId
+  const randomId = Math.random().toString(36).slice(2, 10);
+  return randomId;
+}


### PR DESCRIPTION
## Summary
- add `detectVideo` mock API service
- integrate video detection page with the new service

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68554bd225188331973f8a6455390eb6