### PR TITLE
Refactor video detection feature

### DIFF
--- a/code/src/features/dashboard/components/Navbar.tsx
+++ b/code/src/features/dashboard/components/Navbar.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 
 const navs = [
   { label: "首页", path: "/" },
-  { label: "视频检测", path: "/detect/video" },
+  { label: "视频检测", path: "/video-detect" },
   { label: "设置", path: "/settings" },
 ];
 

--- a/code/src/features/dashboard/mock.tsx
+++ b/code/src/features/dashboard/mock.tsx
@@ -23,7 +23,7 @@ const mockStats = [
     value: 8,
     iconBg: "bg-blue-100 dark:bg-blue-700",
     icon: <Video className="w-6 h-6 text-blue-600 dark:text-blue-200" />,
-    to: "/detect/video", // 示例路径
+    to: "/video-detect", // 示例路径
   },
 ];
 

--- a/code/src/features/detect/video/components/DetectButton.tsx
+++ b/code/src/features/detect/video/components/DetectButton.tsx
@@ -1,8 +1,0 @@
-import React from "react";
-import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
-
-export interface DetectButtonProps {
-
-
-export default DetectButton;

--- a/code/src/features/result/index.tsx
+++ b/code/src/features/result/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const ResultPage: React.FC = () => {
+  return (
+    <div className="p-8">
+      <h1 className="text-xl font-bold mb-4">检测结果</h1>
+      <p>结果页面建设中...</p>
+    </div>
+  );
+};
+
+export default ResultPage;

--- a/code/src/features/video-detect/components/DetectButton.tsx
+++ b/code/src/features/video-detect/components/DetectButton.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { toast } from "sonner";
+
+export interface DetectButtonProps {
+  disabled?: boolean;
+  onClick: () => Promise<void>;
+}
+
+const DetectButton: React.FC<DetectButtonProps> = ({ disabled, onClick }) => {
+  const handleClick = async () => {
+    try {
+      await onClick();
+    } catch (err) {
+      console.error(err);
+      toast.error("检测出错");
+    }
+  };
+
+  return (
+    <button
+      disabled={disabled}
+      onClick={handleClick}
+      className="px-4 py-2 rounded bg-indigo-600 text-white disabled:opacity-50"
+    >
+      开始检测
+    </button>
+  );
+};
+
+export default DetectButton;

--- a/code/src/features/video-detect/components/DetectParams.tsx
+++ b/code/src/features/video-detect/components/DetectParams.tsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { toast } from "sonner";
+import React, { useEffect } from "react";
 
 export interface DetectParamsProps {
-  model?: string;
+  model: string;
   /** 默认选中的模型名称 */
   defaultModel?: string;
   onModelChange: (value: string) => void;
@@ -23,14 +22,19 @@ const DetectParams: React.FC<DetectParamsProps> = ({
   interval,
   onIntervalChange,
 }) => {
+  useEffect(() => {
+    if (defaultModel) {
+      onModelChange(defaultModel);
+    }
+  }, [defaultModel, onModelChange]);
 
   return (
     <div className="space-y-5">
       <div className="space-y-1">
         <label className="block text-sm font-medium">检测模型</label>
         <select
-          {...selectProps}
-          onChange={(e) => handleModelChange(e.target.value)}
+          value={model}
+          onChange={(e) => onModelChange(e.target.value)}
           className="w-full rounded-md border p-2 bg-white dark:bg-gray-800 dark:border-gray-700"
         >
           {models.map((m) => (
@@ -49,11 +53,9 @@ const DetectParams: React.FC<DetectParamsProps> = ({
           max="1"
           required
           value={threshold}
-
+          onChange={(e) => onThresholdChange(parseFloat(e.target.value))}
+          className="w-full rounded-md border p-2 bg-white dark:bg-gray-800 dark:border-gray-700"
         />
-        {thresholdError && (
-          <p className="text-xs text-red-600">{thresholdError}</p>
-        )}
       </div>
       <div className="space-y-1">
         <label className="block text-sm font-medium">帧抽样间隔</label>
@@ -61,10 +63,9 @@ const DetectParams: React.FC<DetectParamsProps> = ({
           type="number"
           min="1"
           value={interval}
-          onChange={(e) => handleInterval(e.target.value)}
+          onChange={(e) => onIntervalChange(parseInt(e.target.value))}
           className="w-full rounded-md border p-2 bg-white dark:bg-gray-800 dark:border-gray-700"
         />
-        {intervalError && <p className="text-xs text-red-600">{intervalError}</p>}
       </div>
     </div>
   );

--- a/code/src/features/video-detect/components/UploadZone.tsx
+++ b/code/src/features/video-detect/components/UploadZone.tsx
@@ -14,22 +14,19 @@ const allowedTypes = [
 
 const UploadZone: React.FC<UploadZoneProps> = ({ onFileChange }) => {
   const [file, setFile] = useState<File | null>(null);
-
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
 
-  // revoke object url when file changed
   useEffect(() => {
     return () => {
-      if (videoUrl) URL.revokeObjectURL(videoUrl);
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
     };
-  }, [videoUrl]);
+  }, [previewUrl]);
 
   const handleFiles = (files: FileList | null) => {
     if (!files || files.length === 0) return;
     const f = files[0];
-    const valid =
-      allowedTypes.includes(f.type) || /\.(mp4|mkv|avi)$/i.test(f.name);
+    const valid = allowedTypes.includes(f.type) || /\.(mp4|mkv|avi)$/i.test(f.name);
     if (!valid) {
       toast.error("只支持 MP4/MKV/AVI 格式");
       return;
@@ -40,19 +37,9 @@ const UploadZone: React.FC<UploadZoneProps> = ({ onFileChange }) => {
     }
     const url = URL.createObjectURL(f);
     setFile(f);
-    setVideoUrl(url);
-    setDuration(0);
+    setPreviewUrl(url);
     onFileChange?.(f);
   };
-
-  useEffect(() => {
-    if (file) {
-      const url = URL.createObjectURL(file);
-      setPreviewUrl(url);
-      return () => URL.revokeObjectURL(url);
-    }
-    setPreviewUrl(null);
-  }, [file]);
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -75,8 +62,8 @@ const UploadZone: React.FC<UploadZoneProps> = ({ onFileChange }) => {
         className="hidden"
         onChange={(e) => handleFiles(e.target.files)}
       />
-      {file ? (
-
+      {file && previewUrl ? (
+        <video className="mx-auto max-h-60" src={previewUrl} controls />
       ) : (
         <p className="text-gray-500 dark:text-gray-400">拖拽或点击上传视频</p>
       )}

--- a/code/src/features/video-detect/index.tsx
+++ b/code/src/features/video-detect/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
+import { useNavigate } from "react-router-dom";
 import UploadZone from "./components/UploadZone";
 import DetectParams from "./components/DetectParams";
 import DetectButton from "./components/DetectButton";
@@ -10,8 +11,26 @@ const DetectPage: React.FC = () => {
   const [model, setModel] = useState<string>("YOLO-Fake");
   const [threshold, setThreshold] = useState<number>(0.7);
   const [interval, setInterval] = useState<number>(1);
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
 
-
+  const handleDetect = async () => {
+    if (!file) {
+      toast.error("请先上传视频");
+      return;
+    }
+    setLoading(true);
+    try {
+      const taskId = await detectVideo(file, { model, threshold, interval });
+      toast.success("任务已提交");
+      navigate(`/result?taskId=${taskId}`);
+    } catch (err) {
+      console.error(err);
+      toast.error("检测失败");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="relative min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white">
@@ -36,7 +55,8 @@ const DetectPage: React.FC = () => {
             defaultModel="YOLO-Fake"
           />
         </div>
-
+        <div className="text-center">
+          <DetectButton disabled={!file || loading} onClick={handleDetect} />
         </div>
       </main>
     </div>

--- a/code/src/routes/index.tsx
+++ b/code/src/routes/index.tsx
@@ -1,12 +1,15 @@
 import { Routes, Route } from "react-router-dom";
 import Dashboard from "../features/dashboard";
+import DetectPage from "../features/video-detect";
+import ResultPage from "../features/result";
 
 
 export default function AppRoutes() {
   return (
     <Routes>
       <Route path="/" element={<Dashboard />} />
-
+      <Route path="/video-detect" element={<DetectPage />} />
+      <Route path="/result" element={<ResultPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- move video detection module to `features/video-detect`
- implement new DetectPage with loading state and navigation
- flesh out `DetectParams`, `UploadZone`, and `DetectButton`
- add simple `ResultPage` and update routes
- update navigation links and mock data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855797f11a483319653702228076c5a