### PR TITLE
Add persistent dark theme toggle

### DIFF
--- a/code/src/components/Navbar.tsx
+++ b/code/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Box } from 'lucide-react';
 import { useLocation, useNavigate } from "react-router-dom";
+import { toggleTheme as toggleThemeUtil } from "../utils/theme";
 
 const navs = [
   { label: "首页", path: "/dashboard" },
@@ -14,8 +15,8 @@ const Navbar: React.FC = () => {
   const location = useLocation();
 
   const toggleTheme = () => {
-    document.documentElement.classList.toggle("dark");
-    setDark(document.documentElement.classList.contains("dark"));
+    const isDark = toggleThemeUtil();
+    setDark(isDark);
   };
 
   const isHistoryPage = location.pathname.startsWith("/history");

--- a/code/src/features/dashboard/components/Navbar.tsx
+++ b/code/src/features/dashboard/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { toggleTheme as toggleThemeUtil } from "../../../utils/theme";
 
 const navs = [
   { label: "首页", path: "/" },
@@ -12,8 +13,8 @@ const Navbar: React.FC = () => {
   const [dark, setDark] = useState(() => document.documentElement.classList.contains("dark"));
 
   const toggleTheme = () => {
-    document.documentElement.classList.toggle("dark");
-    setDark(document.documentElement.classList.contains("dark"));
+    const isDark = toggleThemeUtil();
+    setDark(isDark);
   };
 
   return (

--- a/code/src/main.tsx
+++ b/code/src/main.tsx
@@ -4,6 +4,9 @@ import App from "./App";
 import "./index.css";
 import { initParticlesEngine } from "@tsparticles/react";
 import { loadSlim } from "@tsparticles/slim";
+import { applyStoredTheme } from "./utils/theme";
+
+applyStoredTheme();
 
 initParticlesEngine(async (engine) => {
   await loadSlim(engine);

--- a/code/src/utils/theme.ts
+++ b/code/src/utils/theme.ts
@@ -1,0 +1,18 @@
+export const applyStoredTheme = () => {
+  if (typeof window === 'undefined') return;
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const shouldUseDark = stored === 'dark' || (!stored && prefersDark);
+  if (shouldUseDark) {
+    document.documentElement.classList.add('dark');
+  } else {
+    document.documentElement.classList.remove('dark');
+  }
+};
+
+export const toggleTheme = (): boolean => {
+  if (typeof document === 'undefined') return false;
+  const isDark = document.documentElement.classList.toggle('dark');
+  localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  return isDark;
+};


### PR DESCRIPTION
## Summary
- enable theme persistence on load
- add helper to toggle and store theme
- use helper in navbars

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862cfb3ed4083318c006e6d93828714